### PR TITLE
chore: replaced deprecated way of GCP authentication in cd workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,12 +16,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - id: auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
       - id: deploy
         uses: google-github-actions/deploy-cloudrun@v0
         with:
           service: ${{ secrets.GCP_CLOUDRUN_SERVICE_NAME }}
           region: ${{ secrets.GCP_CLOUDRUN_SERVICE_REGION }}
-          credentials: ${{ secrets.GCP_SA_KEY }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           env_vars: |
             APP_ID=${{ secrets.APP_ID }}


### PR DESCRIPTION
Replaced deprecated way of GCP authentication along with instructions from [docs](https://github.com/google-github-actions/deploy-cloudrun#authenticating-via-service-account-key-json).

resolves nearform/optic-release-automation-app#105