### PR TITLE
feat: accept name prop when creating release

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -66,11 +66,15 @@ async function githubPlugin(app, options) {
     return github.rest.pulls.create(opts)
   }
 
-  async function createDraftRelease({ owner, repo, version, target }, token) {
+  async function createDraftRelease(
+    { owner, repo, version, target, name },
+    token
+  ) {
     const github = new Octokit({ auth: token })
     return github.rest.repos.createRelease({
       owner,
       repo,
+      name,
       tag_name: version,
       target_commitish: target,
       generate_release_notes: true,

--- a/lib/github.js
+++ b/lib/github.js
@@ -74,7 +74,7 @@ async function githubPlugin(app, options) {
     return github.rest.repos.createRelease({
       owner,
       repo,
-      name,
+      ...(name && { name }),
       tag_name: version,
       target_commitish: target,
       generate_release_notes: true,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -16,7 +16,8 @@ const createReleaseSchema = {
   body: S.object()
     .additionalProperties(false) // important
     .prop('version', S.string().required())
-    .prop('target', S.string()),
+    .prop('target', S.string())
+    .prop('name', S.string()),
 }
 
 const publishReleaseSchema = {


### PR DESCRIPTION
Allow release name to be set when creating a new release. This will be useful when releasing monorepo packages which need to have the package name in the release name.

nearform/optic-release-automation-action#177