### PR TITLE
feat: add generateReleaseNotes and releaseNotes

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -97,6 +97,7 @@ test('create release with target specified', async t => {
       {
         version: 'v9.9.9',
         target: 'commit-hash',
+        generateReleaseNotes: true,
         owner: 'salmanm',
         repo: 'smn-repo',
       },
@@ -143,6 +144,7 @@ test('create release with no target specified', async t => {
     createDraftReleaseStub.calledWithExactly(
       {
         version: 'v9.9.9',
+        generateReleaseNotes: true,
         owner: 'salmanm',
         repo: 'smn-repo',
       },

--- a/index.test.js
+++ b/index.test.js
@@ -152,3 +152,53 @@ test('create release with no target specified', async t => {
 
   t.same(response.statusCode, 200)
 })
+
+test('create release with releaseNotes specified', async t => {
+  const mockedRepo = { repo: 'smn-repo', owner: 'salmanm' }
+
+  const getAccessTokenStub = sinon.stub().resolves('some-token')
+  const createDraftReleaseStub = sinon.stub().resolves('some-token')
+
+  const app = await setup(async server => {
+    server.addHook('onRequest', async req => {
+      req.auth = { ...mockedRepo }
+    })
+    server.decorate('github', {
+      getAccessToken: getAccessTokenStub,
+      createDraftRelease: createDraftReleaseStub,
+    })
+  })
+
+  const response = await app.inject({
+    method: 'POST',
+    headers: {
+      authorization: 'token gh-token',
+      'content-type': 'application/json',
+    },
+    url: '/release',
+    body: JSON.stringify({
+      version: 'v9.9.9',
+      generateReleaseNotes: true,
+      releaseNotes: 'my release notes',
+    }),
+  })
+
+  t.same(getAccessTokenStub.callCount, 1)
+  t.ok(getAccessTokenStub.calledWithExactly('salmanm', 'smn-repo'))
+
+  t.same(createDraftReleaseStub.callCount, 1)
+  t.ok(
+    createDraftReleaseStub.calledWithExactly(
+      {
+        version: 'v9.9.9',
+        generateReleaseNotes: true,
+        releaseNotes: 'my release notes',
+        owner: 'salmanm',
+        repo: 'smn-repo',
+      },
+      'some-token'
+    )
+  )
+
+  t.same(response.statusCode, 200)
+})

--- a/index.test.js
+++ b/index.test.js
@@ -185,21 +185,20 @@ test('create release with releaseNotes specified', async t => {
     }),
   })
 
-  t.same(getAccessTokenStub.callCount, 1)
-  t.ok(getAccessTokenStub.calledWithExactly('salmanm', 'smn-repo'))
+  sinon.assert.calledOnce(getAccessTokenStub)
+  sinon.assert.calledWithExactly(getAccessTokenStub, 'salmanm', 'smn-repo')
 
-  t.same(createDraftReleaseStub.callCount, 1)
-  t.ok(
-    createDraftReleaseStub.calledWithExactly(
-      {
-        version: 'v9.9.9',
-        generateReleaseNotes: true,
-        releaseNotes: 'my release notes',
-        owner: 'salmanm',
-        repo: 'smn-repo',
-      },
-      'some-token'
-    )
+  sinon.assert.calledOnce(createDraftReleaseStub)
+  sinon.assert.calledWithExactly(
+    createDraftReleaseStub,
+    {
+      version: 'v9.9.9',
+      generateReleaseNotes: true,
+      releaseNotes: 'my release notes',
+      owner: 'salmanm',
+      repo: 'smn-repo',
+    },
+    'some-token'
   )
 
   t.same(response.statusCode, 200)

--- a/lib/github.js
+++ b/lib/github.js
@@ -77,7 +77,7 @@ async function githubPlugin(app, options) {
       ...(name && { name }),
       tag_name: version,
       target_commitish: target,
-      generate_release_notes: generateReleaseNotes || true,
+      generate_release_notes: generateReleaseNotes,
       ...(releaseNotes && { body: releaseNotes }),
       draft: true,
     })

--- a/lib/github.js
+++ b/lib/github.js
@@ -67,7 +67,7 @@ async function githubPlugin(app, options) {
   }
 
   async function createDraftRelease(
-    { owner, repo, version, target, name },
+    { owner, repo, version, target, name, generateReleaseNotes, releaseNotes },
     token
   ) {
     const github = new Octokit({ auth: token })
@@ -77,7 +77,8 @@ async function githubPlugin(app, options) {
       ...(name && { name }),
       tag_name: version,
       target_commitish: target,
-      generate_release_notes: true,
+      generate_release_notes: generateReleaseNotes || true,
+      ...(releaseNotes && { body: releaseNotes }),
       draft: true,
     })
   }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -17,7 +17,9 @@ const createReleaseSchema = {
     .additionalProperties(false) // important
     .prop('version', S.string().required())
     .prop('target', S.string())
-    .prop('name', S.string()),
+    .prop('name', S.string())
+    .prop('generateReleaseNotes', S.boolean())
+    .prop('releaseNotes', S.string()),
 }
 
 const publishReleaseSchema = {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -18,7 +18,7 @@ const createReleaseSchema = {
     .prop('version', S.string().required())
     .prop('target', S.string())
     .prop('name', S.string())
-    .prop('generateReleaseNotes', S.boolean())
+    .prop('generateReleaseNotes', S.boolean().default(true))
     .prop('releaseNotes', S.string()),
 }
 


### PR DESCRIPTION
Closes #182 

This PR adds two new properties to the createRelease schema in order to choose whether or not generate automatically the release notes and to inject custom release notes.