### PR TITLE
feat: add prerelease param to publish release

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -83,7 +83,10 @@ async function githubPlugin(app, options) {
     })
   }
 
-  async function publishRelease({ owner, repo, version, releaseId }, token) {
+  async function publishRelease(
+    { owner, repo, version, releaseId, isPreRelease },
+    token
+  ) {
     const github = new Octokit({ auth: token })
     return github.rest.repos.updateRelease({
       owner,
@@ -92,6 +95,7 @@ async function githubPlugin(app, options) {
       generate_release_notes: true,
       release_id: releaseId,
       draft: false,
+      prerelease: isPreRelease,
     })
   }
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -26,7 +26,8 @@ const publishReleaseSchema = {
   body: S.object()
     .additionalProperties(false) // important
     .prop('releaseId', S.string().required())
-    .prop('version', S.string().required()),
+    .prop('version', S.string().required())
+    .prop('isPreRelease', S.boolean().default(false)),
 }
 
 async function routesPlugin(app) {


### PR DESCRIPTION
Closes #196 

### Main changes:

- added the new `isPreRelease` parameter in the `publishReleaseSchema` with a default value of `false`
- handled the new `isPreRelease` parameter in the `updateRelease` GitHub API call
- added a test