### PR TITLE
restore node 18.x engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/salmanm/optic-release-automation-app/issues"
   },
   "engines": {
-    "node": "18.12.0"
+    "node": "18.x"
   },
   "homepage": "https://github.com/salmanm/optic-release-automation-app#readme",
   "dependencies": {


### PR DESCRIPTION
It closes #194 

The issue Google side seems to be [fixed](https://github.com/GoogleCloudPlatform/buildpacks/issues/248#issuecomment-1421694250), but we need to try this change by deploying the application to Google Cloud Run and checking the logs.

